### PR TITLE
proxy events in google-map-infowindow component

### DIFF
--- a/lib/components/InfoWindow.js
+++ b/lib/components/InfoWindow.js
@@ -67,8 +67,17 @@ export default {
   mounted () {
     const self = this
     self.observer = new MutationObserver(() => {
-      self.content = self.$el.innerHTML
-      self.$_mapElement.setContent(`<div class="google-map-info-windows">${this.content}</div>`)
+      let content = document.createElement('div')
+
+      content.classList.add('google-map-info-windows')
+
+      for (let childNode of self.$el.childNodes) {
+        content.appendChild(childNode);
+      }
+
+      self.content = content;
+      self.$_mapElement.setContent(self.content)
+
       document.querySelectorAll('.google-map-info-windows').forEach(function (element) {
         element.onclick = function ($event) {
           self.$emit('info-window-clicked', $event)

--- a/src/components/InfoWindows.vue
+++ b/src/components/InfoWindows.vue
@@ -15,8 +15,8 @@
               :options="{maxWidth: 300}"
               @info-window-clicked="infoClicked($event, infowindow)"
       >
-        <h4>{{infoWIndowContext.title}}</h4>
-        <p>{{infoWIndowContext.description}}</p>
+        <h4 @click="handleClick">{{infoWIndowContext.title}}</h4>
+        <p @click="handleClick">{{infoWIndowContext.description}}</p>
       </google-map-infowindow>
     </google-map>
   </div>
@@ -44,6 +44,9 @@ export default {
     },
     infoClicked(context, spot) {
       console.log(context, spot)
+    },
+    handleClick() {
+      console.log('Event!');
     }
   }
 }


### PR DESCRIPTION
Event's not work's in default slot into google-map-infowindow component.

Fix

ver: 0.0.7

step to reproduce:
```html
      <google-map-infowindow
              v-for="(infowindow, index) in infoWindowsList"
              :key="`info-window-${index}`"
              :position="infowindow.position"
              :show.sync="showInfo"
              :options="{maxWidth: 300}"
              @info-window-clicked="infoClicked($event, infowindow)"
      >
        <h4 @click="handleClick">{{infoWIndowContext.title}}</h4>
        <p @click="handleClick">{{infoWIndowContext.description}}</p>
      </google-map-infowindow>
```

```js
    handleClick() {
      console.log('Event!');
    }
```

See in console: ***nothing happenes***