### PR TITLE
Removed hard-coded pac-input id from input in Autocomplete component.

### DIFF
--- a/lib/components/Autocomplete.vue
+++ b/lib/components/Autocomplete.vue
@@ -19,7 +19,7 @@
 
     <div class="pac-input-container">
       <slot name="before-input"></slot>
-      <input id="pac-input" type="text" :value="model" @input="onInputChange" :placeholder="placeholder">
+      <input ref="input" type="text" :value="model" @input="onInputChange" :placeholder="placeholder">
       <slot name="after-input"></slot>
     </div>
   </div>
@@ -108,8 +108,7 @@ export default {
   },
 
   googleMapsReady () {
-    let input = this.$el.querySelector('#pac-input')
-    this.$_autocomplete = new window.google.maps.places.Autocomplete(input)
+    this.$_autocomplete = new window.google.maps.places.Autocomplete(this.$refs.input)
     this.$_autocomplete.setTypes(this.$props.types)
 
     if (this.$_map) {


### PR DESCRIPTION
Removed a hard-coded `#pac-input` id from the input in Autocomplete component and replaced it by the ref mechanism as it allows for instantiation of multiple component instances on the same page.

This resolves #35. 