### PR TITLE
Added google.maps.places.Autocomplete class options as prop to autocomplete component

### DIFF
--- a/lib/components/Autocomplete.vue
+++ b/lib/components/Autocomplete.vue
@@ -64,6 +64,10 @@ export default {
     updateMap: {
       type: Boolean,
       default: true
+    },
+    options: {
+      type: Object,
+      default: () => ({})
     }
   },
   computed: {
@@ -110,7 +114,10 @@ export default {
     this.$_map = mapComp ? await mapComp.$_getMap() : null
   },
   googleMapsReady () {
-    this.$_autocomplete = new window.google.maps.places.Autocomplete(this.$refs.input)
+    this.$_autocomplete = new window.google.maps.places.Autocomplete(
+      this.$refs.input,
+      this.$props.options
+    )
     this.$_autocomplete.setTypes(this.$props.types)
 
     if (this.$_map) {


### PR DESCRIPTION
The `google.maps.places.Autocomplete` class accepts quite a few useful parameters (e.g. bounds, fields, ecc.), this patch adds an optional `options` prop such parameters can be passed through.